### PR TITLE
Pagination interface rework

### DIFF
--- a/client/playwright.config.js
+++ b/client/playwright.config.js
@@ -28,6 +28,6 @@ module.exports = defineConfig({
   webServer: {
     command: 'npm run build && npm run serve',
     url: BASE_URL,
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: false,
   },
 });

--- a/client/src/components/PostsContainer/PostsContainer.vue
+++ b/client/src/components/PostsContainer/PostsContainer.vue
@@ -18,7 +18,7 @@
       <slot name="no-content" />
     </div>
 
-    <div v-if="isNoMorePosts" class="posts-container__no-more">
+    <div v-if="hasNextPage" class="posts-container__no-more">
       <slot name="no-more-content" />
     </div>
 
@@ -46,21 +46,23 @@ export default {
       type: Boolean,
       default: false,
     },
-    isNoMorePosts: {
+    hasNextPage: {
       type: Boolean,
       default: false,
     },
   },
   methods: {
     handleScroll(_, el) {
-      if (!this.isLoading && !this.isNoMorePosts && this.posts.length > 0) {
-        const curContainerBounds = el.getBoundingClientRect();
-        if (
-          curContainerBounds.height - Math.abs(curContainerBounds.y) <
-          window.innerHeight
-        ) {
-          this.$emit('load-more');
-        }
+      if (this.isLoading || !this.hasNextPage) {
+        return;
+      }
+
+      const curContainerBounds = el.getBoundingClientRect();
+      if (
+        curContainerBounds.height - Math.abs(curContainerBounds.y) <
+        window.innerHeight
+      ) {
+        this.$emit('fetch-more');
       }
     },
   },

--- a/client/src/views/PostsCategory.vue
+++ b/client/src/views/PostsCategory.vue
@@ -2,8 +2,8 @@
   <PostsContainer
     :posts="posts"
     :is-loading="isLoading"
-    :is-no-more-posts="isNoMorePosts"
-    @load-more="handleNextPage"
+    :has-next-page="hasNextPage"
+    @fetch-more="handleNextPage"
   >
     <template #no-content>
       No content found at the moment. <br />
@@ -32,7 +32,7 @@ export default {
       isLoading: false,
       posts: [],
       curPage: 0,
-      isNoMorePosts: false,
+      hasNextPage: false,
     };
   },
   watch: {
@@ -40,7 +40,7 @@ export default {
       this.posts = [];
       this.isLoading = false;
       this.curPage = 0;
-      this.isNoMorePosts = false;
+      this.hasNextPage = false;
       this.fetchPosts();
     },
   },
@@ -71,21 +71,16 @@ export default {
 
       const res = await pageRequestsMap[this.$route.name]({
         limit: consts.POSTS_INITIAL_COUNT,
-        offset: 0 + this.curPage * consts.POSTS_INITIAL_COUNT,
+        offset: this.curPage * consts.POSTS_INITIAL_COUNT,
       });
 
       if (res && !res.data.error) {
+        this.hasNextPage = res.data.hasNextPage;
+
         if (isCombine) {
-          if (res.data.posts.length === 0) {
-            this.isNoMorePosts = true;
-          } else {
-            this.posts = this.posts.concat(res.data.posts);
-          }
+          this.posts = this.posts.concat(res.data.posts);
         } else {
           this.posts = res.data.posts;
-          if (res.data.pages === 1) {
-            this.isNoMorePosts = true;
-          }
         }
       }
 

--- a/client/src/views/Search.vue
+++ b/client/src/views/Search.vue
@@ -8,8 +8,8 @@
       v-if="isAnyFilterActive"
       :posts="posts"
       :is-loading="isLoading"
-      :is-no-more-posts="isNoMorePosts"
-      @load-more="handleNextPage"
+      :has-next-page="hasNextPage"
+      @fetch-more="handleNextPage"
     >
       <template #no-content>
         It looks like we couldn't find any posts that match your filters. <br />
@@ -40,7 +40,7 @@ export default {
       isLoading: false,
       posts: [],
       curPage: 0,
-      isNoMorePosts: false,
+      hasNextPage: false,
       filter: {
         title: '',
         ratingFrom: null,
@@ -90,22 +90,17 @@ export default {
 
       const res = await api.posts.search({
         limit: consts.POSTS_INITIAL_COUNT,
-        offset: 0 + this.curPage * consts.POSTS_INITIAL_COUNT,
+        offset: this.curPage * consts.POSTS_INITIAL_COUNT,
         ...filters,
       });
 
       if (res && !res.data.error) {
+        this.hasNextPage = res.data.hasNextPage;
+
         if (isCombine) {
-          if (res.data.posts.length === 0) {
-            this.isNoMorePosts = true;
-          } else {
-            this.posts = this.posts.concat(res.data.posts);
-          }
+          this.posts = this.posts.concat(res.data.posts);
         } else {
           this.posts = res.data.posts;
-          if (res.data.pages === 1) {
-            this.isNoMorePosts = true;
-          }
         }
       }
 

--- a/client/src/views/UserPage.vue
+++ b/client/src/views/UserPage.vue
@@ -5,8 +5,8 @@
     <PostsContainer
       :posts="posts"
       :is-loading="isLoading"
-      :is-no-more-posts="isNoMorePosts"
-      @load-more="handleNextPage"
+      :has-next-page="hasNextPage"
+      @fetch-more="handleNextPage"
     >
       <template #no-content>
         This author has not posted anything yet.
@@ -59,7 +59,7 @@ export default {
       user: {},
       isLoading: false,
       curPage: 0,
-      isNoMorePosts: false,
+      hasNextPage: false,
     };
   },
   async created() {
@@ -80,21 +80,16 @@ export default {
       const res = await api.posts.search({
         author: this.user.login || this.$route.params.login,
         limit: consts.POSTS_INITIAL_COUNT,
-        offset: 0 + this.curPage * consts.POSTS_INITIAL_COUNT,
+        offset: this.curPage * consts.POSTS_INITIAL_COUNT,
       });
 
-      if (!res.data.error) {
+      if (res && !res.data.error) {
+        this.hasNextPage = res.data.hasNextPage;
+
         if (isCombine) {
-          if (res.data.posts.length === 0) {
-            this.isNoMorePosts = true;
-          } else {
-            this.posts = this.posts.concat(res.data.posts);
-          }
+          this.posts = this.posts.concat(res.data.posts);
         } else {
           this.posts = res.data.posts;
-          if (res.data.pages === 1) {
-            this.isNoMorePosts = true;
-          }
         }
       }
 

--- a/client/tests/integration/auth.spec.js
+++ b/client/tests/integration/auth.spec.js
@@ -14,6 +14,8 @@ test.beforeEach(async ({ Api }) => {
     body: {
       pages: 0,
       posts: [],
+      hasNextPage: false,
+      total: 0,
     },
   });
 });

--- a/client/tests/integration/comments.spec.js
+++ b/client/tests/integration/comments.spec.js
@@ -25,8 +25,10 @@ test.beforeEach(async ({ Api }) => {
 
   Api.routes.comments.getComments.mock({
     body: {
-      pages: 0,
+      pages: 1,
       comments: [comment],
+      hasNextPage: false,
+      total: 1,
     },
   });
 });
@@ -73,8 +75,10 @@ test('Shows a deleted comment with different text and no reply button', async ({
 
   Api.routes.comments.getComments.mock({
     body: {
-      pages: 0,
+      pages: 1,
       comments: [deletedComment],
+      hasNextPage: false,
+      total: 1,
     },
   });
 
@@ -226,8 +230,10 @@ test.describe('Votes', () => {
   test.beforeEach(async ({ Api }) => {
     Api.routes.comments.getComments.mock({
       body: {
-        pages: 0,
+        pages: 1,
         comments: [notRatedComment],
+        hasNextPage: false,
+        total: 1,
       },
     });
   });
@@ -319,8 +325,10 @@ test.describe('Votes', () => {
 
     Api.routes.comments.getComments.mock({
       body: {
-        pages: 0,
+        pages: 1,
         comments: [ratedComment],
+        hasNextPage: false,
+        total: 1,
       },
     });
 
@@ -373,8 +381,10 @@ test.describe('Votes', () => {
 
     Api.routes.comments.getComments.mock({
       body: {
-        pages: 0,
+        pages: 1,
         comments: [downvotedComment],
+        hasNextPage: false,
+        total: 1,
       },
     });
 
@@ -427,8 +437,10 @@ test.describe('Editing or deleting a comment', () => {
   test.beforeEach(({ Api }) => {
     Api.routes.comments.getComments.mock({
       body: {
-        pages: 0,
+        pages: 1,
         comments: [currentUserComment],
+        hasNextPage: false,
+        total: 1,
       },
     });
   });
@@ -453,8 +465,10 @@ test.describe('Editing or deleting a comment', () => {
 
     Api.routes.comments.getComments.mock({
       body: {
-        pages: 0,
+        pages: 1,
         comments: [oldComment],
+        hasNextPage: false,
+        total: 1,
       },
     });
 
@@ -481,8 +495,10 @@ test.describe('Editing or deleting a comment', () => {
 
     Api.routes.comments.getComments.mock({
       body: {
-        pages: 0,
+        pages: 1,
         comments: [notCurrentUserComment],
+        hasNextPage: false,
+        total: 1,
       },
     });
 
@@ -667,8 +683,10 @@ test('Formate different dates with relation to the current time correctly', asyn
 
   Api.routes.comments.getComments.mock({
     body: {
-      pages: 0,
+      pages: 1,
       comments,
+      hasNextPage: false,
+      total: comments.length,
     },
   });
 

--- a/client/tests/integration/editor.spec.js
+++ b/client/tests/integration/editor.spec.js
@@ -21,6 +21,8 @@ test.beforeEach(async ({ Api }) => {
     body: {
       pages: 0,
       posts: [],
+      hasNextPage: false,
+      total: 0,
     },
   });
 

--- a/client/tests/integration/posts.spec.js
+++ b/client/tests/integration/posts.spec.js
@@ -29,8 +29,10 @@ test.beforeEach(async ({ Api }) => {
 
   Api.routes.posts.getToday.mock({
     body: {
-      pages: 0,
+      pages: 1,
       posts,
+      hasNextPage: false,
+      total: posts.length,
     },
   });
 });
@@ -54,6 +56,8 @@ test('Empty posts lists', async ({ Api, Post, PostsPage }) => {
     body: {
       pages: 0,
       posts: [],
+      hasNextPage: false,
+      total: 0,
     },
   });
 
@@ -85,8 +89,10 @@ test.describe('Post groups', () => {
     }) => {
       Api.routes.posts.getAll.mock({
         body: {
-          pages: 0,
+          pages: 1,
           posts,
+          hasNextPage: false,
+          total: posts.length,
         },
       });
 
@@ -113,8 +119,10 @@ test.describe('Post groups', () => {
     }) => {
       Api.routes.posts.getBlowing.mock({
         body: {
-          pages: 0,
+          pages: 1,
           posts,
+          hasNextPage: false,
+          total: posts.length,
         },
       });
 
@@ -141,8 +149,10 @@ test.describe('Post groups', () => {
     }) => {
       Api.routes.posts.getTopThisWeek.mock({
         body: {
-          pages: 0,
+          pages: 2,
           posts,
+          hasNextPage: false,
+          total: posts.length,
         },
       });
 
@@ -169,8 +179,10 @@ test.describe('Post groups', () => {
     }) => {
       Api.routes.posts.getRecent.mock({
         body: {
-          pages: 0,
+          pages: 1,
           posts,
+          hasNextPage: false,
+          total: posts.length,
         },
       });
 
@@ -227,8 +239,10 @@ test.describe('Post groups', () => {
 
       Api.routes.posts.getFeed.mock({
         body: {
-          pages: 0,
+          pages: 1,
           posts,
+          hasNextPage: false,
+          total: posts.length,
         },
       });
 
@@ -349,7 +363,9 @@ test.describe('Post votes', () => {
   }) => {
     Api.routes.posts.getToday.mock({
       body: {
-        pages: 0,
+        pages: 1,
+        hasNextPage: false,
+        total: 1,
         posts: [
           {
             ...post1,
@@ -398,7 +414,9 @@ test.describe('Post votes', () => {
   }) => {
     Api.routes.posts.getToday.mock({
       body: {
-        pages: 0,
+        pages: 1,
+        hasNextPage: false,
+        total: 1,
         posts: [
           {
             ...post1,
@@ -455,8 +473,10 @@ test.describe('Sections', () => {
 
     Api.routes.posts.getToday.mock({
       body: {
-        pages: 0,
+        pages: 1,
         posts: [post],
+        hasNextPage: false,
+        total: 1,
       },
     });
 
@@ -480,8 +500,10 @@ test.describe('Sections', () => {
 
     Api.routes.posts.getToday.mock({
       body: {
-        pages: 0,
+        pages: 1,
         posts: [post],
+        hasNextPage: false,
+        total: 1,
       },
     });
 
@@ -506,8 +528,10 @@ test.describe('Sections', () => {
 
     Api.routes.posts.getToday.mock({
       body: {
-        pages: 0,
+        pages: 1,
         posts: [post],
+        hasNextPage: false,
+        total: 1,
       },
     });
 
@@ -546,8 +570,10 @@ test.describe('Sections', () => {
 
     Api.routes.posts.getToday.mock({
       body: {
-        pages: 0,
+        pages: 1,
         posts: [post],
+        hasNextPage: false,
+        total: 1,
       },
     });
 

--- a/client/tests/integration/profile.spec.js
+++ b/client/tests/integration/profile.spec.js
@@ -20,8 +20,10 @@ test.beforeEach(async ({ Api }) => {
 
   Api.routes.posts.getPosts.mock({
     body: {
-      pages: 0,
+      pages: 1,
       posts: [post],
+      hasNextPage: false,
+      total: 1,
     },
   });
 

--- a/client/tests/integration/search.spec.js
+++ b/client/tests/integration/search.spec.js
@@ -13,8 +13,10 @@ test.beforeEach(async ({ Api }) => {
 
   Api.routes.posts.getPosts.mock({
     body: {
-      pages: 0,
+      pages: 1,
       posts: [post],
+      hasNextPage: false,
+      total: 1,
     },
   });
 });
@@ -208,8 +210,10 @@ test('Searches posts by clicking on a tag name and then "Search tag" option in t
 
   Api.routes.posts.getAll.mock({
     body: {
-      pages: 0,
+      pages: 1,
       posts: [postWithSpecificTags],
+      hasNextPage: false,
+      total: 1,
     },
   });
 
@@ -221,6 +225,8 @@ test('Searches posts by clicking on a tag name and then "Search tag" option in t
     body: {
       pages: 0,
       posts: [],
+      hasNextPage: false,
+      total: 0,
     },
   });
 
@@ -247,6 +253,8 @@ test('Empty posts lists after search', async ({
     body: {
       pages: 0,
       posts: [],
+      hasNextPage: false,
+      total: 0,
     },
   });
 

--- a/client/tests/integration/single-post.spec.js
+++ b/client/tests/integration/single-post.spec.js
@@ -26,8 +26,10 @@ test.beforeEach(async ({ Api }) => {
 
   Api.routes.posts.getToday.mock({
     body: {
-      pages: 0,
+      pages: 1,
       posts: [post],
+      hasNextPage: false,
+      total: 1,
     },
   });
 

--- a/server/src/controllers/comments/get-list.js
+++ b/server/src/controllers/comments/get-list.js
@@ -31,7 +31,9 @@ exports.getList = async (req, res) => {
   const limit = +req.query.limit || 10;
   const offset = +req.query.offset || 0;
 
-  const query = {};
+  const query = {
+    parent: { $exists: false },
+  };
 
   if (limit > 30) {
     throw new ValidationError("Limit can't be more than 30");
@@ -56,11 +58,7 @@ exports.getList = async (req, res) => {
   }
 
   const [comments, currentUser, total] = await Promise.all([
-    Comment.find(query)
-      .sort('-rating')
-      .skip(offset)
-      .limit(limit)
-      .exists('parent', false),
+    Comment.find(query).sort({ rating: -1 }).skip(offset).limit(limit),
     User.findById(userId).select('rates').populate('rates'),
     Comment.countDocuments(query),
   ]);

--- a/server/src/controllers/comments/get-list.js
+++ b/server/src/controllers/comments/get-list.js
@@ -55,7 +55,7 @@ exports.getList = async (req, res) => {
     query.author = foundAuthor.id;
   }
 
-  const [comments, currentUser, count] = await Promise.all([
+  const [comments, currentUser, total] = await Promise.all([
     Comment.find(query)
       .sort('-rating')
       .skip(offset)
@@ -67,6 +67,8 @@ exports.getList = async (req, res) => {
 
   sendSuccess(res, {
     comments: fillWithRatedRecursive({ comments, user: currentUser }),
-    pages: Math.ceil(count / limit),
+    total,
+    pages: Math.ceil(total / limit),
+    hasNextPage: offset + limit < total,
   });
 };

--- a/server/src/controllers/posts/categories/all.js
+++ b/server/src/controllers/posts/categories/all.js
@@ -13,7 +13,7 @@ exports.all = async (req, res) => {
     throw new ValidationError('Limit cannot be more than 15');
   }
 
-  const [posts, user, count] = await Promise.all([
+  const [posts, user, total] = await Promise.all([
     Post.find()
       .sort({ rating: -1 })
       .populate('author', 'login avatar')
@@ -26,7 +26,9 @@ exports.all = async (req, res) => {
   const postsWithRated = posts.map((post) => post.toResponse(user));
 
   sendSuccess(res, {
-    pages: Math.ceil(count / limit),
     posts: postsWithRated,
+    total,
+    pages: Math.ceil(total / limit),
+    hasNextPage: offset + limit < total,
   });
 };

--- a/server/src/controllers/posts/categories/blowing.js
+++ b/server/src/controllers/posts/categories/blowing.js
@@ -24,7 +24,7 @@ exports.blowing = async (req, res) => {
     },
   };
 
-  const [posts, user, count] = await Promise.all([
+  const [posts, user, total] = await Promise.all([
     Post.find(query)
       .sort({ rating: -1 })
       .populate('author', 'login avatar')
@@ -37,7 +37,9 @@ exports.blowing = async (req, res) => {
   const postsWithRated = posts.map((post) => post.toResponse(user));
 
   sendSuccess(res, {
-    pages: Math.ceil(count / limit),
     posts: postsWithRated,
+    total,
+    pages: Math.ceil(total / limit),
+    hasNextPage: offset + limit < total,
   });
 };

--- a/server/src/controllers/posts/categories/recent.js
+++ b/server/src/controllers/posts/categories/recent.js
@@ -21,7 +21,7 @@ exports.recent = async (req, res) => {
     },
   };
 
-  const [posts, user, count] = await Promise.all([
+  const [posts, user, total] = await Promise.all([
     Post.find(query)
       .sort({ createdAt: -1 })
       .populate('author', 'login avatar')
@@ -34,7 +34,9 @@ exports.recent = async (req, res) => {
   const postsWithRated = posts.map((post) => post.toResponse(user));
 
   sendSuccess(res, {
-    pages: Math.ceil(count / limit),
     posts: postsWithRated,
+    total,
+    pages: Math.ceil(total / limit),
+    hasNextPage: offset + limit < total,
   });
 };

--- a/server/src/controllers/posts/categories/today.js
+++ b/server/src/controllers/posts/categories/today.js
@@ -21,7 +21,7 @@ exports.today = async (req, res) => {
     },
   };
 
-  const [posts, user, count] = await Promise.all([
+  const [posts, user, total] = await Promise.all([
     Post.find(query)
       .sort({ rating: -1 })
       .populate('author', 'login avatar')
@@ -34,7 +34,9 @@ exports.today = async (req, res) => {
   const postsWithRated = posts.map((post) => post.toResponse(user));
 
   sendSuccess(res, {
-    pages: Math.ceil(count / limit),
     posts: postsWithRated,
+    total,
+    pages: Math.ceil(total / limit),
+    hasNextPage: offset + limit < total,
   });
 };

--- a/server/src/controllers/posts/categories/top-this-week.js
+++ b/server/src/controllers/posts/categories/top-this-week.js
@@ -21,7 +21,7 @@ exports.topThisWeek = async (req, res) => {
     },
   };
 
-  const [posts, user, count] = await Promise.all([
+  const [posts, user, total] = await Promise.all([
     Post.find(query)
       .sort({ createdAt: -1 })
       .populate('author', 'login avatar')
@@ -34,7 +34,9 @@ exports.topThisWeek = async (req, res) => {
   const postsWithRated = posts.map((post) => post.toResponse(user));
 
   sendSuccess(res, {
-    pages: Math.ceil(count / limit),
     posts: postsWithRated,
+    total,
+    pages: Math.ceil(total / limit),
+    hasNextPage: offset + limit < total,
   });
 };

--- a/server/src/controllers/posts/get-feed.js
+++ b/server/src/controllers/posts/get-feed.js
@@ -38,7 +38,7 @@ exports.getFeed = async (req, res) => {
     ],
   };
 
-  const [posts, count] = await Promise.all([
+  const [posts, total] = await Promise.all([
     Post.find(query)
       .sort('-createdAt')
       .populate('author', 'login avatar')
@@ -50,7 +50,9 @@ exports.getFeed = async (req, res) => {
   const transPosts = posts.map((post) => post.toResponse(user));
 
   sendSuccess(res, {
-    pages: Math.ceil(count / limit),
     posts: transPosts,
+    total,
+    pages: Math.ceil(total / limit),
+    hasNextPage: offset + limit < total,
   });
 };

--- a/server/src/controllers/posts/get-list-by-author.js
+++ b/server/src/controllers/posts/get-list-by-author.js
@@ -26,7 +26,7 @@ exports.getListByAuthor = async (req, res) => {
     author: foundAuthor.id,
   };
 
-  const [posts, user, count] = await Promise.all([
+  const [posts, user, total] = await Promise.all([
     Post.find(query)
       .sort({ createdAt: -1 })
       .populate('author', 'login avatar')
@@ -39,7 +39,9 @@ exports.getListByAuthor = async (req, res) => {
   const postsWithRated = posts.map((post) => post.toResponse(user));
 
   sendSuccess(res, {
-    pages: Math.ceil(count / limit),
     posts: postsWithRated,
+    total,
+    pages: Math.ceil(total / limit),
+    hasNextPage: offset + limit < total,
   });
 };

--- a/server/src/controllers/posts/search.js
+++ b/server/src/controllers/posts/search.js
@@ -76,7 +76,7 @@ exports.search = async (req, res) => {
     };
   }
 
-  const [posts, user, count] = await Promise.all([
+  const [posts, user, total] = await Promise.all([
     Post.find(query)
       .sort({ rating: -1 })
       .populate('author', 'login avatar')
@@ -89,7 +89,9 @@ exports.search = async (req, res) => {
   const postsWithRated = posts.map((post) => post.toResponse(user));
 
   sendSuccess(res, {
-    pages: Math.ceil(count / limit),
     posts: postsWithRated,
+    total,
+    pages: Math.ceil(total / limit),
+    hasNextPage: offset + limit < total,
   });
 };

--- a/server/src/routes/api/comments.js
+++ b/server/src/routes/api/comments.js
@@ -163,6 +163,12 @@ const authRequiredMiddleware = require('../../middlewares/auth-required');
                   "pages": {
                     "type": "number",
                     "default": 1
+                  },
+                  "hasNextPage": {
+                    "type": "boolean"
+                  },
+                  "total": {
+                    "type": "number"
                   }
                 }
               }

--- a/server/src/routes/api/posts.js
+++ b/server/src/routes/api/posts.js
@@ -99,6 +99,12 @@ const authRequiredMiddleware = require('../../middlewares/auth-required');
           },
           "pages": {
             "type": "number"
+          },
+          "hasNextPage": {
+            "type": "boolean"
+          },
+          "total": {
+            "type": "number"
           }
         }
       },

--- a/server/src/swagger/swagger.json
+++ b/server/src/swagger/swagger.json
@@ -241,6 +241,12 @@
                     "pages": {
                       "type": "number",
                       "default": 1
+                    },
+                    "hasNextPage": {
+                      "type": "boolean"
+                    },
+                    "total": {
+                      "type": "number"
                     }
                   }
                 }
@@ -1723,6 +1729,12 @@
             }
           },
           "pages": {
+            "type": "number"
+          },
+          "hasNextPage": {
+            "type": "boolean"
+          },
+          "total": {
             "type": "number"
           }
         }


### PR DESCRIPTION
**Changes:**

Backend:

- Update all posts fetching controllers to include new fields in the response: `hasNextPage`, `total`, `pages`
- Fix wrong total comments count calculation

Frontend:

- Rework & refactor posts and comments fetching logic. _Now it won't do an additional request to check if there is more content available to stop fetching more for infinite scroll
- Update integration tests to reflect the changes